### PR TITLE
Update scroll-container.js

### DIFF
--- a/addon/system/scroll-container.js
+++ b/addon/system/scroll-container.js
@@ -11,7 +11,8 @@ export default class ScrollContainer {
       this.scrollHeight = document.documentElement.clientHeight;
     } else {
       let { top, left } = this.element.getBoundingClientRect();
-      this.top = top;
+      // this.top = top;
+      this.top = $(window).scrollTop();
       this.left = left;
       this.width = parseFloat(getComputedStyle(this.element).width);
       this.height = parseFloat(getComputedStyle(this.element).height);


### PR DESCRIPTION
When we do dragging and reach the top/bottom then only, automatic scroll(top/bottom) should happen.
The above mentioned function works properly for the first time(means when we reach the bootm of/top of the page on the first window).After that if click the element to drag, that time itself the automatic scroll happens

This code change will fix the issue